### PR TITLE
Update Beam to 2.27 and samza to 1.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ You can run directly within the project using maven:
 
 ```
 $ mvn compile exec:java -Dexec.mainClass=org.apache.beam.examples.KafkaWordCount \
-    -Dexec.args="--runner=SamzaRunner" -P samza-runner
+    -Dexec.args="--runner=SamzaRunner --experiments=use_deprecated_read" -P samza-runner
 ```
 
 #### Packaging Your Application

--- a/pom.xml
+++ b/pom.xml
@@ -27,8 +27,8 @@
   <packaging>jar</packaging>
 
   <properties>
-    <beam.version>2.11.0</beam.version>
-    <samza.version>0.14.1</samza.version>
+    <beam.version>2.27.0</beam.version>
+    <samza.version>1.3.0</samza.version>
 
     <guava.version>20.0</guava.version>
     <hamcrest.version>1.3</hamcrest.version>
@@ -182,7 +182,7 @@
 
     <dependency>
       <groupId>org.apache.samza</groupId>
-      <artifactId>samza-log4j</artifactId>
+      <artifactId>samza-log4j_2.11</artifactId>
       <version>${samza.version}</version>
     </dependency>
 
@@ -208,6 +208,12 @@
       <groupId>org.apache.samza</groupId>
       <artifactId>samza-core_2.11</artifactId>
       <version>${samza.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+      <version>2.0.1</version>
     </dependency>
 
     <!-- Dependencies below this line are specific dependencies needed by the examples code. -->

--- a/src/main/bash/run-beam-container.sh
+++ b/src/main/bash/run-beam-container.sh
@@ -33,4 +33,4 @@ cd $home_dir
 
 override="{\"task.execute\":\"bin/run-beam-container.sh $@\"}"
 
-exec $(dirname $0)/run-class.sh $1 --runner=org.apache.beam.runners.samza.SamzaRunner --configFactory=org.apache.beam.runners.samza.container.ContainerCfgFactory --configOverride="$override" "${@:2}"
+exec $(dirname $0)/run-class.sh $1 --runner=org.apache.beam.runners.samza.SamzaRunner --configFactory=org.apache.beam.runners.samza.container.ContainerCfgFactory --configOverride="$override" --samzaExecutionEnvironment=YARN --experiments=use_deprecated_read "${@:2}"

--- a/src/main/bash/run-beam-standalone.sh
+++ b/src/main/bash/run-beam-standalone.sh
@@ -20,4 +20,4 @@
 
 override="{\"task.execute\":\"bin/run-beam-container.sh $@\"}"
 
-exec $(dirname $0)/run-class.sh $1 --runner=org.apache.beam.runners.samza.SamzaRunner --configOverride="$override" "${@:2}"
+exec $(dirname $0)/run-class.sh $1 --runner=org.apache.beam.runners.samza.SamzaRunner --configOverride="$override" --experiments=use_deprecated_read "${@:2}"

--- a/src/main/bash/run-beam-yarn.sh
+++ b/src/main/bash/run-beam-yarn.sh
@@ -33,7 +33,7 @@ override="{\"task.execute\":\"bin/run-beam-container.sh $@\"}"
 
 case $op in
   run)
-    exec $(dirname $0)/run-class.sh $1 --runner=org.apache.beam.runners.samza.SamzaRunner --configOverride="$override" "${@:2}"
+    exec $(dirname $0)/run-class.sh $1 --runner=org.apache.beam.runners.samza.SamzaRunner --configOverride="$override" --samzaExecutionEnvironment=YARN --experiments=use_deprecated_read "${@:2}"
   ;;
 
   kill)


### PR DESCRIPTION
Update the beam examples on samza runner to use the latest beam version. 

Note that we found problems when dealing with splitable parDo so we use the flag --experiments=use_deprecated_read to disable it for now.